### PR TITLE
refactor(animation): Use react-transition-state

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -8,7 +8,7 @@ export default [
   { 
     path: 'build/Button/index.cjs',
     name: 'Button direct import (Common JS)',
-    limit: '10 kb',
+    limit: '11.5 kb',
     running: false,
   },
   {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/jest": "^26.0.19",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@types/react-transition-group": "^4.4.11",
     "@types/requestidlecallback": "^0.3.1",
     "@types/styled-system": "^5.1.10",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -115,7 +114,7 @@
     "deepmerge": "^4.2.2",
     "isobject": "^4.0.0",
     "nanopop": "^2.4.2",
-    "react-transition-group": "^4.4.5",
+    "react-transition-state": "^2.2.0",
     "use-resize-observer": "^9.1.0"
   },
   "resolutions": {

--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -64,6 +64,8 @@ const StyledIconButton = styled.button<IconButtonProps>`
 
   ${getCustomStyles('iconButton.styles', 'root')}
 
+  ${(props) => props.css}
+
   ${(props) =>
     props.active
       ? css`

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -34,6 +34,8 @@ const PopoverWrapper = styled.div`
   z-index: 1100;
 `;
 
+const DefaultArrow = styled.div``;
+
 export const Popover = forwardRef(
   (
     {
@@ -47,7 +49,7 @@ export const Popover = forwardRef(
       onMouseLeave = () => {},
       onClick,
       onClickOutside = () => {},
-      arrow = <div />,
+      arrow = <DefaultArrow />,
       animation: Animation = NoAnimation,
       animationProps = { duration: 0 },
       'aria-haspopup': ariaHasPopup,

--- a/src/ToastCard/ToastCard.tsx
+++ b/src/ToastCard/ToastCard.tsx
@@ -72,6 +72,7 @@ export const ToastCard = forwardRef<HTMLDivElement, ToastCardProps>(
     const generatedId = useUniqueId();
     const titleId = `${generatedId}-title`;
     const descriptionId = `${generatedId}-title`;
+    console.log('color', color);
 
     return (
       <CardWrapper
@@ -109,7 +110,7 @@ export const ToastCard = forwardRef<HTMLDivElement, ToastCardProps>(
               {closable && (
                 <IconButton
                   data-testid="pbl-toastcard-closebtn"
-                  mx={-5}
+                  mx={-1.5}
                   onClick={onClose}
                   size="small"
                   css={(props) =>

--- a/src/ToastCard/ToastCard.tsx
+++ b/src/ToastCard/ToastCard.tsx
@@ -72,7 +72,6 @@ export const ToastCard = forwardRef<HTMLDivElement, ToastCardProps>(
     const generatedId = useUniqueId();
     const titleId = `${generatedId}-title`;
     const descriptionId = `${generatedId}-title`;
-    console.log('color', color);
 
     return (
       <CardWrapper

--- a/src/ToastProvider/ToastProvider.tsx
+++ b/src/ToastProvider/ToastProvider.tsx
@@ -38,8 +38,6 @@ export function ToastProvider({ children, side = 'bottom-right' }: ToastProvider
 
   const removeMessage = useCallback(
     (id: string) => {
-      console.log('xxxxxx');
-
       if (mountedRef.current) {
         dispatchMessage({
           type: 'remove',
@@ -99,7 +97,7 @@ export function ToastProvider({ children, side = 'bottom-right' }: ToastProvider
                   role={isAlert ? 'alert' : 'status'}
                   aria-atomic="true"
                   {...message}
-                  mb={4}
+                  mb={1.5}
                   onClose={() => hideMessage(message.id!)}
                 />
               </StackAnimation>

--- a/src/Tooltip/Tooltip.spec.tsx
+++ b/src/Tooltip/Tooltip.spec.tsx
@@ -319,6 +319,11 @@ describe.each([
       jest.advanceTimersByTime(1);
     });
 
+    // Advance one more time to trigger "entering" state of the animation
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
     expect(getByTestId('pbl-animation-inner')).toHaveStyleRule('opacity', '1');
     expect(getByTestId('pbl-animation-inner')).toHaveStyleRule(
       'transform',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,7 +1011,7 @@
     pirates "^4.0.6"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -2844,13 +2844,6 @@
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.1.tgz#1e4654c08a9cdcfb6594c780ac59b55aad42fe07"
   integrity sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-transition-group@^4.4.11":
-  version "4.4.11"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.11.tgz#d963253a611d757de01ebb241143b1017d5d63d5"
-  integrity sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==
   dependencies:
     "@types/react" "*"
 
@@ -4845,14 +4838,6 @@ dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
-
-dom-helpers@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -8663,7 +8648,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8863,16 +8848,6 @@ react-reconciler@^0.26.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
-
-react-transition-group@^4.4.5:
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
-  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
 
 react-transition-state@^2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8874,6 +8874,11 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-transition-state@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-transition-state/-/react-transition-state-2.2.0.tgz#3a9f37c0553a865b6110ae8eaf7ed4db22633577"
+  integrity sha512-D3EyLku1Sdxrxq26Fo4Jh0q1BLEFQfDOxKKiSuyqWH84+hM6y0Guc0hcW2IXMXY5l5gQCgkOQ9y90xx6mNoj5w==
+
 react@18.3.1, react@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"


### PR DESCRIPTION
Dropping `react-transition-group` library. The `group` library wasn't maintained for two years, uses deprecated react API and was too big. With this change, we save another `2.45kb`.